### PR TITLE
Removes an old workaround that no longer is needed. Thus it is being …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ ENV APP_HOME /app
 RUN mkdir -p  $APP_HOME  /app-dependencies/  /root/.ssh
 
 ADD Gemfile* /app-dependencies/
-ADD id_rsa /root/.ssh/id_rsa
-RUN chmod 400 /root/.ssh/id_rsa                      && \
-    ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
 RUN cd /app-dependencies/ && \
     bundle install


### PR DESCRIPTION
…removed since it is a possible security risk due to the fact it copies a user key into a docker image